### PR TITLE
Make sure amount has two decimal places

### DIFF
--- a/CRM/Recurmaster/Master.php
+++ b/CRM/Recurmaster/Master.php
@@ -47,7 +47,7 @@ class CRM_Recurmaster_Master {
           $amount += $lDetail['amount'];
         }
       }
-      $contributionRecur['amount'] = $amount;
+      $contributionRecur['amount'] = number_format($amount, 2, '.', '');
       if ($contributionRecur != $originalContributionRecur) {
         Civi::log()->debug('CRM_Recurmaster_Master::update: Calculated amount for R' . $contributionRecur['id'] . ' is ' . $contributionRecur['amount']);
         $recurResult = civicrm_api3('ContributionRecur', 'create', $contributionRecur);


### PR DESCRIPTION
SmartDebit expects to receive amounts in pennies. Or if there's a decimal in the amount it's assumed to be pounds, and it's then converted to pennies. The amount calculated from the linked recurs risks being in pounds, but with no decimal places - so gets interpreted as pennies. Safest is to always pass through a value with two decimal places.